### PR TITLE
Adding restrart policy mechanism

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM balenalib/aarch64-alpine:run
 
-COPY fan-control.sh /fan-control.sh
-RUN chmod +x /fan-control.sh
+COPY fan-control.sh restart-policy.sh /
+RUN chmod +x /fan-control.sh /restart-policy.sh
 
-CMD /fan-control.sh
+CMD /restart-policy.sh /fan-control.sh

--- a/restart-policy.sh
+++ b/restart-policy.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# This script manages restrart policy for Fan Block scrit
+# This takes one argument which is the program to run, and will restart it
+# when it crashes for a given amount of retries.
+
+RETRIES=${RETRIES:-5}
+LOCK=${LOCK:-1}
+
+if [ -z $1 ]; then
+  echo "Usage: $0 program_to_run"
+  exit 0
+fi
+
+while [ $RETRIES -gt 0 ];do
+  echo "Starting $1"
+  $1
+  RETRIES=$(($RETRIES - 1))
+  echo "Program stopped, $RETRIES left"
+done
+
+if [ $LOCK -ne 0 ];then
+  echo "Starting failed, locking"
+  while : ; do
+    sleep 3600
+  done
+fi


### PR DESCRIPTION
To prevent the script from cashlooping when the device is not available, adding a `restart_policy` script that will retry running the fan control script 5 times before waiting indefinitely.

Change-type: patch